### PR TITLE
Add cursor support to vscode on ubuntu22

### DIFF
--- a/~/install_cursor.sh
+++ b/~/install_cursor.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+echo "==================================="
+echo "Cursor IDE 간단 설치 스크립트"
+echo "==================================="
+
+# Downloads 폴더에서 Cursor AppImage 찾기
+CURSOR_FILE=$(ls ~/Downloads/cursor*.AppImage 2>/dev/null | head -1)
+
+if [ -z "$CURSOR_FILE" ]; then
+    echo "❌ ERROR: Cursor AppImage를 찾을 수 없습니다!"
+    echo ""
+    echo "📥 설치 방법:"
+    echo "1. https://cursor.sh 웹사이트 방문"
+    echo "2. 'Download for Linux' 버튼 클릭"
+    echo "3. 다운로드 완료 후 이 스크립트 다시 실행"
+    exit 1
+fi
+
+echo "✅ Cursor 파일 발견: $CURSOR_FILE"
+
+# 실행 권한 부여
+chmod +x "$CURSOR_FILE"
+
+# 홈 디렉토리에 복사
+cp "$CURSOR_FILE" ~/cursor.AppImage
+
+echo ""
+echo "==================================="
+echo "✅ 설치 완료!"
+echo "==================================="
+echo ""
+echo "🚀 Cursor 실행 방법:"
+echo "   ~/cursor.AppImage"
+echo ""
+echo "💡 터미널에서 'cursor' 명령어로 실행하려면:"
+echo "   sudo ln -s ~/cursor.AppImage /usr/local/bin/cursor"


### PR DESCRIPTION
Create a script to simplify Cursor IDE AppImage installation on Ubuntu 22. This script automates finding the downloaded AppImage, making it executable, and copying it for easier execution, addressing the user's request for a streamlined installation process.

---
<a href="https://cursor.com/background-agent?bcId=bc-82835232-6c34-447d-bd25-3af8509dac7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82835232-6c34-447d-bd25-3af8509dac7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

